### PR TITLE
Fix default selected locale in settings/account page.

### DIFF
--- a/app/views/settings/accounts/show.html.slim
+++ b/app/views/settings/accounts/show.html.slim
@@ -21,7 +21,7 @@
           .form-group
             = f.label :locale, class: 'control-label col-sm-3'
             .col-sm-6
-              = f.select :locale, I18n.available_locales.map { |locale| [t("locales.#{locale}"), locale] }, {}, class: 'form-control', tabIndex: 3
+              = f.select :locale, I18n.available_locales.map { |locale| [t("locales.#{locale}"), locale] }, { selected: locale }, class: 'form-control', tabIndex: 3
           .form-group
             = label_tag :current_password, t('.current_password'), class: 'control-label col-sm-3'
             .col-sm-6


### PR DESCRIPTION
現在註冊完畢時，若瀏覽器預設語系是中文，則註冊完到設置頁面，語言會是英文，但介面卻是中文：

![screenshot 2014-03-04 21 37 24](https://f.cloud.github.com/assets/1000669/2321360/2441b4e2-a3a2-11e3-9ba6-c59782707003.png)

加入預設選項不知道合不合用？
