### PR TITLE
fix login_required 下 redirect_to 跳转

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,10 @@ class ApplicationController < ActionController::Base
 
   def login_required
     unless login?
-      redirect_to login_path(return_to: (request.fullpath if request.get?))
+      respond_to do |format|
+        format.js { redirect_via_turbolinks_to login_path(return_to: (request.fullpath if request.get?)) }
+        format.html { redirect_to login_path(return_to: (request.fullpath if request.get?)) }
+      end
     end
   end
 


### PR DESCRIPTION
![2015-07-15 12 18 39](https://cloud.githubusercontent.com/assets/1763737/8690887/cc7e7b86-2aec-11e5-9a96-c4d372fb24f1.png)

我在没登录的情况下会跳转到登录页面，不过因为 *_turbolinks *_ 的原因，页面并没有跳转

`#app/controllers/application_controller.rb` 

```
  def login_required
    unless login?
      respond_to do |format|
        format.js { redirect_via_turbolinks_to login_path(return_to: (request.fullpath if request.get?)) }
        format.html { redirect_to login_path(return_to: (request.fullpath if request.get?)) }
      end
    end
  end
```

我需改了这段代码。不知道能否修复这个问题。
